### PR TITLE
Add deployment.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A curated list of amazing Deployment tools and services.
   * [Capistrano](http://capistranorb.com) - A remote server automation and deployment tool written in Ruby.
   * [Spinnaker](http://spinnaker.io) - Multi-Cloud immutable infrastructure deployment tool from Netflix.
   * [Stacktape](http://stacktape.com) - DevOps-free cloud framework for deploying applications to AWS.
+  * [Deployment.io](https://deployment.io) - DevOps co-pilot for developers to automate deployments to AWS.
 
 
 ## Services


### PR DESCRIPTION
Deployment.io is a DevOps co-pilot for developers to automate deployments to AWS.